### PR TITLE
Create conversation on compatible target

### DIFF
--- a/app/controllers/api/v1/targets_controller.rb
+++ b/app/controllers/api/v1/targets_controller.rb
@@ -9,6 +9,7 @@ module Api
 
       def create
         @target = current_user.targets.create!(target_params)
+        @conversations = @target.conversations_of_matched_targets
       end
 
       def destroy

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -16,6 +16,17 @@ class Conversation < ApplicationRecord
 
   scope :with_unread_messages, -> { joins(:messages).where(messages: { read: false }).group(:id) }
 
+  scope :users_in_conversation, lambda { |users_id|
+                                  joins('INNER JOIN user_conversations uc_two ON
+                                  conversations.id = uc_two.conversation_id')
+                                    .where('uc_two.user_id': users_id)
+                                }
+
+  def connect_user(user)
+    user_conv = user_conversations.of_user(user.id).first
+    user_conv.update!(connected: true)
+  end
+
   def create_message(user, text)
     other_user_conversation = user_conversations.not_of_user(user.id).first
     created_message = messages.create!(
@@ -26,14 +37,18 @@ class Conversation < ApplicationRecord
     created_message.broadcast_message(other_user_conversation)
   end
 
-  def connect_user(user)
-    user_conv = user_conversations.of_user(user.id).first
-    user_conv.update!(connected: true)
-  end
-
   def disconnect_user(user)
     user_conv = user_conversations.of_user(user.id).first
     user_conv.update!(connected: false)
+  end
+
+  def self.get_or_create_by_users(first_user, second_user)
+    old_conversation = first_user.conversations.users_in_conversation([second_user]).first
+    old_conversation || Conversation.create!(users: [first_user, second_user])
+  end
+
+  def self.get_converastions_of_user_with(original_user, with_users)
+    original_user.conversations.users_in_conversation(with_users)
   end
 
   private

--- a/app/views/api/v1/targets/_conversation.json.jbuilder
+++ b/app/views/api/v1/targets/_conversation.json.jbuilder
@@ -1,0 +1,4 @@
+json.id conversation.id
+json.users do
+  json.array!(conversation.users, partial: 'user', as: :user)
+end

--- a/app/views/api/v1/targets/_user.json.jbuilder
+++ b/app/views/api/v1/targets/_user.json.jbuilder
@@ -1,0 +1,1 @@
+json.id user.id

--- a/app/views/api/v1/targets/create.json.jbuilder
+++ b/app/views/api/v1/targets/create.json.jbuilder
@@ -1,0 +1,3 @@
+json.conversations do
+  json.array!(@conversations, partial: 'conversation', as: :conversation)
+end

--- a/spec/controllers/api/v1/conversations/conversations_index_spec.rb
+++ b/spec/controllers/api/v1/conversations/conversations_index_spec.rb
@@ -32,7 +32,7 @@ describe 'GET /api/v1/conversations', type: :request do
         has_unread_messages: true
       }
       get api_v1_conversations_path, params: params
-      response_body = JSON.parse(response.body)
+      response_body = json
       expect(response).to have_http_status(:success)
       expect(response_body['conversations'].length).to be(1)
       expect(response_body['conversations'][0].keys).to contain_exactly('id', 'users')
@@ -41,7 +41,7 @@ describe 'GET /api/v1/conversations', type: :request do
 
     it 'returns only the conversations of the user' do
       get api_v1_conversations_path
-      response_body = JSON.parse(response.body)
+      response_body = json
       expect(response).to have_http_status(:success)
       expect(response_body['conversations'].length).to be(2)
     end

--- a/spec/controllers/api/v1/targets/targets_index_spec.rb
+++ b/spec/controllers/api/v1/targets/targets_index_spec.rb
@@ -15,7 +15,7 @@ describe 'GET /api/v1/targets', type: :request do
 
     it 'returns all and only the targets for the user' do
       get api_v1_targets_path
-      response_body = JSON.parse(response.body)
+      response_body = json
       expect(response_body['targets'].length).to be(10)
       expect(response_body['targets'][0].keys).to contain_exactly(
         'id', 'lat', 'lng', 'title', 'topic_id', 'user_id'

--- a/spec/controllers/api/v1/users/users_show_spec.rb
+++ b/spec/controllers/api/v1/users/users_show_spec.rb
@@ -14,7 +14,7 @@ describe 'GET /api/v1/users/{id}', type: :request do
 
     it 'returns the user profile' do
       get api_v1_user_path(other_users[0][:id])
-      response_body = JSON.parse(response.body)
+      response_body = json
       expect(response_body.keys).to contain_exactly(
         'created_at', 'email', 'first_name', 'gender', 'id', 'name', 'updated_at', 'username'
       )

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -43,4 +43,22 @@ RSpec.describe Conversation, type: :model do
       is_expected.to include(I18n.t('api.conversation.user_validation.errors.different'))
     end
   end
+
+  context 'validate function get_or_create_by_users' do
+    let(:users) { create_list(:user, 3) }
+
+    it 'creates 2 different conversations with those messages' do
+      expect(Conversation.get_or_create_by_users(users[0], users[1]).users.map(&:id))
+        .to include(users[0][:id], users[1][:id])
+    end
+
+    context 'conversation of two users was already created' do
+      let!(:old_conversation) { create(:conversation, users: [users[0], users[1]]) }
+
+      it 'returns the conversation already created' do
+        expect(Conversation.get_or_create_by_users(users[0], users[1])[:id])
+          .to be(old_conversation[:id])
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require 'active_record/errors'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -64,6 +65,7 @@ RSpec.configure do |config|
   # Helpers
   config.include Requests::AuthHelpers::Includables, type: :request
   config.extend Requests::AuthHelpers::Extensions, type: :request
+  config.include RequestSpecHelper, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'factory_bot'
 require 'support/requests/auth_helpers.rb'
+require 'support/requests/request_spec_helper.rb'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/requests/request_spec_helper.rb
+++ b/spec/support/requests/request_spec_helper.rb
@@ -1,0 +1,6 @@
+module RequestSpecHelper
+  # Parse JSON response to ruby hash
+  def json
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
Done:
 - [x] Created conversations for compatible targets
 - [x] Return conversations with the users of compatible targets when creating one
 - [x] Tests for the flow

Related to US:

> As a user I should be able to see all my compatible targets so I can start a conversation with any of my compatible users

