### PR TITLE
Add translations for texts

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -42,7 +42,7 @@ class Target < ApplicationRecord
   def notify_matched_users
     targets_users.each do |matched_user|
       NotificationsJob.perform_later(
-        [matched_user.push_token], I18n.t('models.target.notification.match'),
+        [matched_user.push_token], I18n.t('api.targets.notification.match'),
         username: matched_user.username
       )
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,15 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  models:
-    target:
+  api:
+    sessions:
+      facebook:
+        forbidden:
+          'Forbidden sign in with Facebook'
+        already_registered:
+          'Already registered with Facebook'
+    targets:
+      create:
+        limit_reached: 'Reached maximum of targets per user'
       notification:
-        match: 'You have a new match!'
+        match: 'You have a new match'

--- a/spec/controllers/api/v1/targets/targets_create_spec.rb
+++ b/spec/controllers/api/v1/targets/targets_create_spec.rb
@@ -41,7 +41,7 @@ describe 'POST /api/v1/targets', type: :request do
       post api_v1_targets_path, params: params
       expect(NotificationsService).to have_received(:notify).with(
         [compatible_target.user.push_token],
-        I18n.t('models.target.notification.match'),
+        I18n.t('api.targets.notification.match'),
         username: compatible_target.user.username
       )
     end


### PR DESCRIPTION
Added some **missing translations** for errors when _sign/up/in_ with Facebook and when reaching _max Targets_ per user.